### PR TITLE
be more tolerant on PACKAGE_NAME argument

### DIFF
--- a/create-xdc.sh
+++ b/create-xdc.sh
@@ -6,10 +6,10 @@ case "$1" in
         exit
         ;;
     "")
-        PACKAGE_NAME=${PWD##*/}
+        PACKAGE_NAME=${PWD##*/} # '##*/' removes everything before the last slash and the last slash
         ;;
     *)
-        PACKAGE_NAME=$1
+        PACKAGE_NAME=${1%.xdc} # '%.xdc' removes the extension and allows PACKAGE_NAME to be given with or without extension
         ;;
 esac
 


### PR DESCRIPTION
when a package name is given to `create-xdc.sh`,
this may be just a copy+pasted filename.
that, however, results in double `.xdc` extensions.

this pr accepts PACKAGE_NAME with or without .xdc extensions,
of course, when creating the final ZIP, .xdc is always added,
however only once :)

moreover, this pr documents the weird string manipulation commands.