### PR TITLE
add the optional properties to ReceivedStatusUpdate

### DIFF
--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -22,6 +22,10 @@ type ReceivedStatusUpdate<T> = {
   serial: number;
   /** the maximum serial currently known */
   max_serial: number;
+  /** optional, short, informational message. */
+  info?: string;
+  /** optional, short text, shown beside app icon. If there are no updates, an empty JSON-array is returned. */
+  summary?: string;
 };
 
 interface Webxdc<T> {


### PR DESCRIPTION
the docs in `deltachat.h` mention these, so I assume they are returned here too.

are they returned? is this addition correct?