### PR TITLE
refactor: add a comment about the `webxdc.js` file

### DIFF
--- a/webxdc.js
+++ b/webxdc.js
@@ -1,6 +1,6 @@
 // This file originates from
 // https://github.com/webxdc/hello/blob/master/webxdc.js
-// It's a stub `webxdc.js` that adds a webxdc API stub for easier testing in
+// It's a stub `webxdc.js` that adds a webxdc API stub for easy testing in
 // browsers. In an actual webxdc environment (e.g. Delta Chat messenger) this
 // file is not used and will automatically be replaced with a real one.
 // See https://docs.webxdc.org/spec.html#webxdc-api


### PR DESCRIPTION
This is important to note in the file itself since currently we
recommend (see README.md) developers to copy-paste the file to their
project, which might be confusing if the file's origin is not described
elsewhere